### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,9 @@ Dotfiles and setup scripts for my terminal experience. Settings for bash, tmux, 
 
 # intallation
 from anywhere:
-`curl -o loader.sh https://raw.githubusercontent.com/jeffreychizever/chizever-config/refs/heads/main/loader.sh && ./loader.sh`
+```bash
+curl -o loader.sh https://raw.githubusercontent.com/jeffreychizever/chizever-config/refs/heads/main/loader.sh
+chmod +x loader.sh
+./loader.sh
+```
 


### PR DESCRIPTION
The current command has no permissions to run loader.sh due to insufficient execution permissions. In the interest of using the shebang, have added a chmod +x in liu of running bash loader.sh explicitly.